### PR TITLE
Add support for absolute URLs

### DIFF
--- a/src/httpx.js
+++ b/src/httpx.js
@@ -178,27 +178,20 @@ class Httpx {
 
   request(method, url, body, params) {
     // console.log(`start ${method} ${url}`)
-    let finalUrl;
 
     params = this._getMergedSessionParams(params);
 
     if(isHttpUrl(url)){
-      params.tags['name'] = url.name
-      if(isAbsoluteUrl(url.url)) {
-        finalUrl = url.url
-      } else {
-        finalUrl = this.baseURL + url.url;
-      }
-    } else {
-      if(isAbsoluteUrl(url)){
-        finalUrl = url;
-      } else {
-        finalUrl = this.baseURL + url;
-      }
+      params.tags['name'] = url.name;
+      url = url.url
+    }
+
+    if(!isAbsoluteUrl(url)){
+      url = this.baseURL + url;
     }
 
     let start_t = new Date();
-    let resp = http.request(method, finalUrl, body, params);
+    let resp = http.request(method, url, body, params);
     let end_t = new Date();
 
     this.postRequestHook(resp, params, start_t, end_t);

--- a/src/httpx.js
+++ b/src/httpx.js
@@ -7,6 +7,10 @@ function isHttpUrl(obj){  // detects type of http.url`http://example.com/{$id}`
     && 'clean_url' in obj
 }
 
+function isAbsoluteUrl(url) {
+  return url.startsWith('http');
+}
+
 class Request {
   constructor(method, url, params) {
     params = params || {};
@@ -174,16 +178,27 @@ class Httpx {
 
   request(method, url, body, params) {
     // console.log(`start ${method} ${url}`)
+    let finalUrl;
 
     params = this._getMergedSessionParams(params);
 
     if(isHttpUrl(url)){
       params.tags['name'] = url.name
-      url = url.url
+      if(isAbsoluteUrl(url.url)) {
+        finalUrl = url.url
+      } else {
+        finalUrl = this.baseURL + url.url;
+      }
+    } else {
+      if(isAbsoluteUrl(url)){
+        finalUrl = url;
+      } else {
+        finalUrl = this.baseURL + url;
+      }
     }
 
     let start_t = new Date();
-    let resp = http.request(method, this.baseURL + url, body, params);
+    let resp = http.request(method, finalUrl, body, params);
     let end_t = new Date();
 
     this.postRequestHook(resp, params, start_t, end_t);

--- a/tests/http.url.test.js
+++ b/tests/http.url.test.js
@@ -31,4 +31,12 @@ export default function() {
       });
     });
 
+    describe('02. Absolute URLs override the baseURL', (t) => {
+      let relativeURL = session.get('/public/crocodiles/1'); //
+      let absoluteURL = session.get('https://httpbin.test.k6.io/get'); // should work.
+
+      t.expect(relativeURL.status).as("relative URL").toEqual(200);
+      t.expect(absoluteURL.status).as("absolute URL").toEqual(200);
+    });
+
 }


### PR DESCRIPTION
This PR allows the user to override the `baseURL` specified during `Httpx` instantiation by providing an absolute URL, i.e. one beginning with `http`. 

It adds a bit of flexibility, and might catch a user error should they forget that they've specified a `baseURL`.

In my case, I am adding two variables to the baseURL:

```javascript
const BASE_URL = 'https://www.somesite.com';
const API_PREFIX = '/api';

const session = new Httpx({
  baseURL: BASE_URL + API_PREFIX
});
```

But a minority of requests don't have the `API_PREFIX`, so instead of reverting to `http.get` and specifying the absolute URL, with this PR I can continue using `session.get` (with an absolute URL).