### PR TITLE
Fix merge of request params

### DIFF
--- a/src/httpx.js
+++ b/src/httpx.js
@@ -98,7 +98,7 @@ class Httpx {
       delete otherK6Params[o];
     });
 
-    Object.assign(this.k6params, otherK6Params);
+    this.k6params = Object.assign(this.k6params, otherK6Params);
 
     this.baseURL = baseURL;
     this.lastRequest = {


### PR DESCRIPTION
This PR fixes the params of the constructor is not passed to `request()`.
It makes it easy to set common parameters among requests as documented.

This PR is related to issue #5.