### PR TITLE
Add node-free k6 CI and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{js,json,yaml,yml}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Test
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+
+jobs:
+  k6-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install k6
+        uses: grafana/setup-k6-action@v1
+
+      - name: Run k6 tests
+        run: |
+          for test in tests/*.test.js; do
+            echo "::group::k6 run $test"
+            k6 run "$test"
+            echo "::endgroup::"
+          done


### PR DESCRIPTION
## What

This repo's library (`src/httpx.js`) is already plain JavaScript with **no npm/node tooling** — nothing to remove. This PR just adds the two things that were missing:

- **`.github/workflows/test.yml`** — runs the k6 tests on push/PR via `grafana/setup-k6-action`. The repo had no CI before.
- **`.editorconfig`** — preserves the existing 2-space style with no tooling.

## Notes

- The tests set no thresholds, so `k6 run` exits 0 even if a live-endpoint check is flaky — CI stays green as long as the library loads and runs. (Tests hit `test-api.k6.io` / `httpbin.test.k6.io`.)
- Part of a cross-repo effort to drop unnecessary npm/node tooling from the k6 jslibs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)